### PR TITLE
Fix pair_loader_csv util

### DIFF
--- a/pretrain/dataloader/dataloader.py
+++ b/pretrain/dataloader/dataloader.py
@@ -27,7 +27,8 @@ sentence1, sentence2
 '''
 def pair_loader_csv(args):
     delimiter = "," if args.dataname.endswith(".csv") else "\t"
-    train_data = list(csv.reader(os.path.join(args.datapath, args.dataname), delimiter=delimiter))
+    with open(os.path.join(args.datapath, args.dataname), "r") as f:
+        train_data = list(csv.reader(f, delimiter=delimiter))
     train_text1 = [d[0] for d in train_data]
     train_text2 = [d[1] for d in train_data]
     pairsimi = [1 for _ in train_data]


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*
`csv.reader` expects a file handler, not a string. This PR fixes that and correctly produces a `train_loader`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
